### PR TITLE
Added block updates and Super Basic Liquid Spread Technique.

### DIFF
--- a/src/main/java/net/redstonelamp/block/Block.java
+++ b/src/main/java/net/redstonelamp/block/Block.java
@@ -17,6 +17,7 @@
 package net.redstonelamp.block;
 
 import net.redstonelamp.item.Item;
+import net.redstonelamp.level.position.BlockPosition;
 
 /**
  * Base class for all blocks
@@ -27,5 +28,10 @@ public class Block extends Item{
 
     public Block(int id, short meta, int count){
         super(id, meta, count);
+    }
+
+    public void update(BlockPosition position) {
+        //Do something if we should be.
+        //For most this is nothing, so just override where necessary.
     }
 }

--- a/src/main/java/net/redstonelamp/block/Liquid.java
+++ b/src/main/java/net/redstonelamp/block/Liquid.java
@@ -16,6 +16,8 @@
  */
 package net.redstonelamp.block;
 
+import net.redstonelamp.level.position.BlockPosition;
+
 /**
  * Abstract class for liquids (water & lava).
  *
@@ -26,4 +28,26 @@ public abstract class Liquid extends Transparent {
     public Liquid(int id, short meta, int count) {
         super(id, meta, count);
     }
+
+    @Override
+    public void update(BlockPosition position) {
+        //Super Basic Liquid Spread Technique. Now in stores near you!
+        BlockPosition[] adj = new BlockPosition[5]; //It is five because we don't need the block above us.
+
+        //Get the surrounding block's positions.
+        adj[0] = new BlockPosition(position.getX() - 1, position.getY(), position.getZ(), position.getLevel());
+        adj[1] = new BlockPosition(position.getX() + 1, position.getY(), position.getZ(), position.getLevel());
+        adj[2] = new BlockPosition(position.getX(), position.getY() - 1, position.getZ(), position.getLevel());
+        adj[3] = new BlockPosition(position.getX(), position.getY(), position.getZ() - 1, position.getLevel());
+        adj[4] = new BlockPosition(position.getX(), position.getY(), position.getZ() + 1, position.getLevel());
+
+        for(int i = 0; i < 5; i++) {
+            //Check if the adjecent block is empty (air (0))
+            if(position.getLevel().getBlock(adj[i]).getId() == 0) {
+                //Block is air, fill with water.
+                position.getLevel().setBlockNoUpdate(adj[i], position.getLevel().getBlock(position));
+            }
+            //Block occupied, do nothing.
+        }
+    }               
 }

--- a/src/main/java/net/redstonelamp/block/Transparent.java
+++ b/src/main/java/net/redstonelamp/block/Transparent.java
@@ -16,6 +16,8 @@
  */
 package net.redstonelamp.block;
 
+import net.redstonelamp.level.position.BlockPosition;
+
 /**
  * Abstract class for transparent blocks such as tall-grass.
  *
@@ -25,5 +27,10 @@ public abstract class Transparent extends Block {
 
     public Transparent(int id, short meta, int count) {
         super(id, meta, count);
+    }
+
+    @Override
+    public void update(BlockPosition position) {
+        
     }
 }

--- a/src/main/java/net/redstonelamp/level/Level.java
+++ b/src/main/java/net/redstonelamp/level/Level.java
@@ -197,9 +197,33 @@ public class Level{
             sendBlockQueues();
             blockPlaceQueue.add(new BlockPlaceResponse(block, position));
         }
+        update(position);
+    }
+
+    public void setBlockNoUpdate(BlockPosition position, Block block){
+        Chunk c = getChunkAt(new ChunkPosition(position.getX() >> 4, position.getZ() >> 4));
+        c.setBlockId((byte) block.getId(), position.getX() & 0x0f, position.getY() & 0x7f, position.getZ() & 0x0f);
+        c.setBlockMeta((byte) block.getMeta(), position.getX() & 0x0f, position.getY() & 0x7f, position.getZ() & 0x0f);
+        if(!blockPlaceQueue.offer(new BlockPlaceResponse(block, position))){
+            //Queue is full, send immediately then
+            sendBlockQueues();
+            blockPlaceQueue.add(new BlockPlaceResponse(block, position));
+        }
     }
 
     public void removeBlock(BlockPosition position){
+        Chunk c = getChunkAt(new ChunkPosition(position.getX() >> 4, position.getZ() >> 4));
+        c.setBlockId((byte) 0, position.getX() & 0x0f, position.getY() & 0x7f, position.getZ() & 0x0f); //Set block to AIR
+        c.setBlockMeta((byte) 0, position.getX() & 0x0f, position.getY() & 0x7f, position.getZ() & 0x0f);
+        if(!removeBlockQueue.offer(new RemoveBlockResponse(position))){
+            //Queue is full, send immediately then
+            sendBlockQueues();
+            removeBlockQueue.add(new RemoveBlockResponse(position));
+        }
+        update(position);
+    }
+
+    public void removeBlockNoUpdate(BlockPosition position){
         Chunk c = getChunkAt(new ChunkPosition(position.getX() >> 4, position.getZ() >> 4));
         c.setBlockId((byte) 0, position.getX() & 0x0f, position.getY() & 0x7f, position.getZ() & 0x0f); //Set block to AIR
         c.setBlockMeta((byte) 0, position.getX() & 0x0f, position.getY() & 0x7f, position.getZ() & 0x0f);
@@ -216,6 +240,26 @@ public class Level{
         byte meta = c.getBlockMeta(position.getX() & 0x0f, position.getY() & 0x7f, position.getZ() & 0x0f);
         //return new Block(id, meta, 1);
         return (Block) Block.get(id, meta, 1);
+    }
+
+    private void update(BlockPosition position) {
+        BlockPosition[] adj = new BlockPosition[6];
+
+        //Get the surrounding block's positions.
+        adj[0] = new BlockPosition(position.getX() - 1, position.getY(), position.getZ(), position.getLevel());
+        adj[1] = new BlockPosition(position.getX() + 1, position.getY(), position.getZ(), position.getLevel());
+        adj[2] = new BlockPosition(position.getX(), position.getY() - 1, position.getZ(), position.getLevel());
+        adj[3] = new BlockPosition(position.getX(), position.getY() + 1, position.getZ(), position.getLevel());
+        adj[4] = new BlockPosition(position.getX(), position.getY(), position.getZ() - 1, position.getLevel());
+        adj[5] = new BlockPosition(position.getX(), position.getY(), position.getZ() + 1, position.getLevel());
+
+		//Update our block first
+        getBlock(position).update(position);
+
+        //Update surrounding blocks
+        for(int i = 0; i < 6; i++) {
+            getBlock(adj[i]).update(adj[i]);
+        }
     }
 
     public LevelManager getManager(){


### PR DESCRIPTION
### What this adds
Block updates and liquid spreading.


### Limitations / Bugs
Liquid only spreads one block. 


### Why does it only do that
This is because it doesn't work in a spiral if it tells the next block to update on placement. it just goes on and on in one direction. So I made it place spreading liquid without updates.


### Possible solution
Perhaps there could be a tick event that has a queue. whenever a liquid is updated or placed, add it to the queue. when it ticks use only the existing queue to tell the world to spread the liquid 1 block in all available directions. Just a thought, and since it seems like a lot of work I'd like to get some ideas before I set out for that.


### Other notes
I tried to comment as clear and as much as possible. Hopefully this helps in coming up with a better/more realistic liquid spread technique.